### PR TITLE
Public access for NPM

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -14,6 +14,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "npm run build"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "BCH",
     "Bitcoin",


### PR DESCRIPTION
This PR is adding public access flag to package.json so the `npm publish` command wouldn't fail (scoped packages are private by default)