### PR TITLE
add SPA fallback for paths

### DIFF
--- a/packages/wallet/vercel.json
+++ b/packages/wallet/vercel.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Redirecting 404 urls to the index to fix the bug that happens when users reload the current path.